### PR TITLE
fix: quote launch options

### DIFF
--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -35,4 +35,4 @@ if [ "${LAUNCH_OPTIONS}" ]; then
   logger -t ${SNAP_NAME} "Running with options: ${LAUNCH_OPTIONS}"
 fi
 
-ros2 launch foxglove_bridge foxglove_bridge_launch.xml ${LAUNCH_OPTIONS}
+ros2 launch foxglove_bridge foxglove_bridge_launch.xml "${LAUNCH_OPTIONS}"


### PR DESCRIPTION
by default in sh strings are evaluated in single quotes causing the single quotes already present to be back-slashed causing:

```
malformed launch argument ''/tf',', expected format '<name>:=<value>'
```