### PR TITLE
fix(launch): treat int and str argument differently

### DIFF
--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -2,8 +2,13 @@
 
 LAUNCH_OPTIONS=""
 
-OPTIONS="port
-address
+INT_OPTIONS="port
+min-qos-depth
+max-qos-depth
+num-threads
+send-buffer-limit"
+
+STR_OPTIONS="address
 tls
 certfile
 keyfile
@@ -11,20 +16,23 @@ topic-whitelist
 param-whitelist
 service-whitelist
 client-topic-whitelist
-min-qos-depth
-max-qos-depth
-num-threads
-send-buffer-limit
 use-sim-time
 use-compression
 capabilities
 include-hidden
 asset-uri-allowlist"
 
-for OPTION in ${OPTIONS}; do
-  VALUE="$(snapctl get ${OPTION})"
+for OPTION in ${INT_OPTIONS}; do
+  VALUE=$(snapctl get ${OPTION})
   if [ -n "${VALUE}" ]; then
     LAUNCH_OPTIONS="${LAUNCH_OPTIONS} ${OPTION}:=${VALUE}"
+  fi
+done
+
+for OPTION in ${STR_OPTIONS}; do
+  VALUE=$(snapctl get ${OPTION})
+  if [ -n "${VALUE}" ]; then
+    LAUNCH_OPTIONS="${LAUNCH_OPTIONS} ${OPTION}:=\"${VALUE}\""
   fi
 done
 
@@ -35,4 +43,5 @@ if [ "${LAUNCH_OPTIONS}" ]; then
   logger -t ${SNAP_NAME} "Running with options: ${LAUNCH_OPTIONS}"
 fi
 
-ros2 launch foxglove_bridge foxglove_bridge_launch.xml "${LAUNCH_OPTIONS}"
+bash -c "ros2 launch foxglove_bridge foxglove_bridge_launch.xml ${LAUNCH_OPTIONS}"
+


### PR DESCRIPTION
Int values cannot be passed as ROS argument under quotes (i.e: `PORT:="123"`).
On the other side, the white-list is a list of single quote string in a double quote string.
We had to use bash -c otherwise sh was intepreting `'` as `'\''`.