### PR TITLE
fix: execute ros2 launch inside bash -c cmd

### DIFF
--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -35,4 +35,4 @@ if [ "${LAUNCH_OPTIONS}" ]; then
   logger -t ${SNAP_NAME} "Running with options: ${LAUNCH_OPTIONS}"
 fi
 
-ros2 launch foxglove_bridge foxglove_bridge_launch.xml "${LAUNCH_OPTIONS}"
+bash -c "ros2 launch foxglove_bridge foxglove_bridge_launch.xml ${LAUNCH_OPTIONS}"

--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -24,7 +24,7 @@ asset-uri-allowlist"
 for OPTION in ${OPTIONS}; do
   VALUE="$(snapctl get ${OPTION})"
   if [ -n "${VALUE}" ]; then
-    LAUNCH_OPTIONS="${LAUNCH_OPTIONS} ${OPTION}:=${VALUE}"
+    LAUNCH_OPTIONS="${LAUNCH_OPTIONS} ${OPTION}:=\"${VALUE}\""
   fi
 done
 


### PR DESCRIPTION
With this, the LAUNCH_OPTIONS quotes are not reinterpreted and there is no need to differentiate ints and strings