### PR TITLE
Revert "fix: enforce double quote on launch argument"

### DIFF
--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -35,4 +35,4 @@ if [ "${LAUNCH_OPTIONS}" ]; then
   logger -t ${SNAP_NAME} "Running with options: ${LAUNCH_OPTIONS}"
 fi
 
-ros2 launch foxglove_bridge foxglove_bridge_launch.xml "${LAUNCH_OPTIONS}"
+ros2 launch foxglove_bridge foxglove_bridge_launch.xml ${LAUNCH_OPTIONS}


### PR DESCRIPTION
Reverts canonical/ros-foxglove-bridge-snap#9