### PR TITLE
Fix/white list string

### DIFF
--- a/snap/local/config_from_content_snap.sh
+++ b/snap/local/config_from_content_snap.sh
@@ -7,8 +7,30 @@ if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
   exit 1
 fi
 
-snapctl set port=$(yq '.port // 54321' $CONFIGURATION_FILE_PATH)
-snapctl set address=$(yq '.address // "0.0.0.0"' $CONFIGURATION_FILE_PATH)
-snapctl set topic-whitelist="$(yq '.topic-whitelist // "*"' $CONFIGURATION_FILE_PATH)"
+OPTIONS="port
+address
+tls
+certfile
+keyfile
+topic-whitelist
+param-whitelist
+service-whitelist
+client-topic-whitelist
+min-qos-depth
+max-qos-depth
+num-threads
+send-buffer-limit
+use-sim-time
+use-compression
+capabilities
+include-hidden
+asset-uri-allowlist"
+
+for OPTION in ${OPTIONS}; do
+  VALUE="$(yq -e ".${OPTION}" $CONFIGURATION_FILE_PATH || true)"
+  if [ "${VALUE}" != null ]; then
+    snapctl set "${OPTION}"="${VALUE}"
+  fi
+done
 
 $SNAP/usr/bin/validate_config.sh

--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -35,4 +35,4 @@ if [ "${LAUNCH_OPTIONS}" ]; then
   logger -t ${SNAP_NAME} "Running with options: ${LAUNCH_OPTIONS}"
 fi
 
-ros2 launch foxglove_bridge foxglove_bridge_launch.xml "${LAUNCH_OPTIONS}"
+ros2 launch foxglove_bridge foxglove_bridge_launch.xml ${LAUNCH_OPTIONS}

--- a/snap/local/validate_config.sh
+++ b/snap/local/validate_config.sh
@@ -58,4 +58,12 @@ for opt in tls include_hidden use_sim_time use_compression; do
   fi
 done
 
+# Enforce bash list as a string synthax
+for opt in topic-whitelist param-whitelist service-whitelist client-topic-whitelist; do
+  VALUE=$(snapctl get "${opt}")
+  if [ -n "${VALUE}" ]; then
+    snapctl set "${opt}"=$(echo ${VALUE} | tr -d ' ')
+  fi
+done
+
 # @todo assert the rest of the parameters.


### PR DESCRIPTION
- Revert #9 
- Validate string list by removing ` ` char in the string representation
- Make any foxglove-bridge argument settable with the content sharing option
- Remove default values if not set by the content sharing
