### PR TITLE
Fix/noetic version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,7 +45,9 @@ parts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCATKIN_ENABLE_TESTING=OFF
     source: https://github.com/foxglove/ros-foxglove-bridge.git
-    source-tag: 0.7.10
+    source-tag: 0.8.4
+    build-packages:
+      - libpoco-dev
     stage-snaps:
       - yq
     stage-packages:


### PR DESCRIPTION
Noetic branch was no longer building due to a missing build package: https://github.com/canonical/ros-foxglove-bridge-snap/actions/runs/14055997752

I added the `libpoco-dev` missing package and bumped the version to the most recent one.