### PR TITLE
fix: update snap version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: foxglove-bridge
-version: '0.7.10'
+version: '0.8.4'
 license: MIT
 summary: Foxglove WebSocket bridge for ROS and ROS 2.
 description: |


### PR DESCRIPTION
The `source-tag` was updated but not the version of the snap.