### PR TITLE
Humble - Preserve dashes in bridge launch option values

### DIFF
--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -24,12 +24,13 @@ asset-uri-allowlist"
 for OPTION in ${OPTIONS}; do
   VALUE="$(snapctl get ${OPTION})"
   if [ -n "${VALUE}" ]; then
-    LAUNCH_OPTIONS="${LAUNCH_OPTIONS} ${OPTION}:=${VALUE}"
+    # Replace '-' with '_' in option keys,
+    # because snap parameters use dashes,
+    # while ROS 2 launch files expect underscores.
+    OPTION_KEY=$(echo "${OPTION}" | tr - _)
+    LAUNCH_OPTIONS="${LAUNCH_OPTIONS} ${OPTION_KEY}:=${VALUE}"
   fi
 done
-
-# Replace '-' with '_'
-LAUNCH_OPTIONS=$(echo ${LAUNCH_OPTIONS} | tr - _)
 
 if [ "${LAUNCH_OPTIONS}" ]; then
   logger -t ${SNAP_NAME} "Running with options: ${LAUNCH_OPTIONS}"


### PR DESCRIPTION
### Issue

The launch script was replacing  `-` with  `_` on the entire `LAUNCH_OPTIONS` string sent to the foxglove-bridge launch file. This modified both option keys and values, resulting in parameters such as `certfile:=/folder-cert/cert` to get changed to `/folder_cert/cert`.

### Solution
This PR replaces '-' with '_' only in option keys to avoid modifying values. 
