### PR TITLE
Humble - certs slots

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,10 +22,14 @@ plugs:
   configuration-read:
     interface: content
     target: $SNAP_COMMON/configuration
-  rob-cos-common-read:
-    interface: content
-    target: $SNAP_COMMON/rob-cos-shared-data
 
+# A slot for writing TLS certificates
+slots:
+  foxglove-certs:
+    interface: content
+    write: 
+      - $SNAP_COMMON/foxglove-certs
+ 
 apps:
   config-from-content-snap:
     command: usr/bin/config_from_content_snap.sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,9 @@ plugs:
   configuration-read:
     interface: content
     target: $SNAP_COMMON/configuration
+  rob-cos-common-read:
+    interface: content
+    target: $SNAP_COMMON/rob-cos-shared-data
 
 apps:
   config-from-content-snap:
@@ -32,7 +35,7 @@ apps:
   foxglove-bridge:
     command: usr/bin/launch.sh
     daemon: simple
-    plugs: [network, network-bind]
+    plugs: [network, network-bind, rob-cos-common-read]
     extensions: [ros2-humble]
 
   reset-config:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,7 +35,7 @@ apps:
   foxglove-bridge:
     command: usr/bin/launch.sh
     daemon: simple
-    plugs: [network, network-bind, rob-cos-common-read]
+    plugs: [network, network-bind]
     extensions: [ros2-humble]
 
   reset-config:


### PR DESCRIPTION
add rob-cos-common-read to be able to read foxglove bridge TLS certs.