### PR TITLE
Add content sharing plug to read tls certs

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,13 +1,13 @@
 name: snap
 on:
   push:
-    tags:
-      - 'noetic/*'
     branches:
-      - noetic
+      - cos-noetic
+    paths:
+      - 'snap/**'
   pull_request:
     branches:
-      - noetic
+      - cos-noetic
   workflow_dispatch:
 
 concurrency:
@@ -22,5 +22,5 @@ jobs:
     with:
       snapcraft-enable-experimental-extensions: true
       runs-on: '["ubuntu-latest", ["self-hosted", "linux", "ARM64", "medium", "noble"]]'
-      snap-track: noetic
+      snap-track: cos-noetic
       snap-risk: candidate

--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -24,15 +24,16 @@ asset-uri-allowlist"
 for OPTION in ${OPTIONS}; do
   VALUE="$(snapctl get ${OPTION})"
   if [ -n "${VALUE}" ]; then
-    LAUNCH_OPTIONS="${LAUNCH_OPTIONS} ${OPTION}:=${VALUE}"
+    # Replace '-' with '_' in option keys,
+    # because snap parameters use dashes,
+    # while ROS launch files expect underscores.
+    OPTION_KEY=$(echo "${OPTION}" | tr - _)
+    LAUNCH_OPTIONS="${LAUNCH_OPTIONS} ${OPTION_KEY}:=${VALUE}"
   fi
 done
-
-# Replace '-' with '_'
-LAUNCH_OPTIONS=$(echo ${LAUNCH_OPTIONS} | tr - _)
 
 if [ "${LAUNCH_OPTIONS}" ]; then
   logger -t ${SNAP_NAME} "Running with options: ${LAUNCH_OPTIONS}"
 fi
 
-roslaunch foxglove_bridge foxglove_bridge.launch ${LAUNCH_OPTIONS}
+roslaunch foxglove_bridge foxglove_bridge_launch.xml ${LAUNCH_OPTIONS}

--- a/snap/local/launch.sh
+++ b/snap/local/launch.sh
@@ -36,4 +36,4 @@ if [ "${LAUNCH_OPTIONS}" ]; then
   logger -t ${SNAP_NAME} "Running with options: ${LAUNCH_OPTIONS}"
 fi
 
-roslaunch foxglove_bridge foxglove_bridge_launch.xml ${LAUNCH_OPTIONS}
+roslaunch foxglove_bridge foxglove_bridge.launch ${LAUNCH_OPTIONS}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,10 @@ plugs:
   configuration-read:
     interface: content
     target: $SNAP_COMMON/configuration
+  # Plug to read TLS cert files
+  rob-cos-common-read:
+    interface: content
+    target: $SNAP_COMMON/rob-cos-shared-data
 
 apps:
   config-from-content-snap:


### PR DESCRIPTION
 Add content sharing plug to read tls certs when snap used in cos for devices.
 Fix bug in launch arguments.